### PR TITLE
Forbid view function reverts

### DIFF
--- a/lesson3_violations/Borda/Borda.spec
+++ b/lesson3_violations/Borda/Borda.spec
@@ -217,6 +217,10 @@ ghost mapping(address => uint256) points_mirror {
  init_state axiom forall address c. points_mirror[c] == 0;
 } 
 
+ghost mapping(address => bool) voted_mirror {
+	init_state axiom forall address c. !voted_mirror[c];
+}
+
 ghost mathint countVoters {
     init_state axiom countVoters == 0;
 }
@@ -235,7 +239,8 @@ hook Sload uint256 curr_point _points[KEY address a]  STORAGE {
 }
 
 hook Sstore _voted[KEY address a] bool val (bool old_val) STORAGE {
-  countVoters = countVoters +1;
+  countVoters = countVoters + 1;
+  voted_mirror[a] = val;
 }
 
 
@@ -253,4 +258,10 @@ rule resolvabilityCriterion(address f, address s, address t, address tie) {
   Each voter contribute a total of 6 points, so the sum of all points is six time the number of voters 
 */
 invariant sumOfPoints() 
-    sumPoints == countVoters * 6; 
+    sumPoints == countVoters * 6;
+
+
+// ADDED RULES:
+
+invariant votedFunctionIsVotedMapping()
+	forall address a. voted_mirror[a] == voted(a);

--- a/lesson3_violations/Borda/Borda.spec
+++ b/lesson3_violations/Borda/Borda.spec
@@ -275,3 +275,11 @@ rule preferLastVotedHigh(address f, address s, address t) {
 	assert (points(w) == points(s) => points(w) == prev_points || w == f || w == s);
 	assert (points(w) == points(t) => points(w) == prev_points || w == f || w == s || w == t);
 }
+
+rule onlyVotingCanChangeTheWinner(env e, method m){
+    address winnerBefore = winner();
+    calldataarg args; 
+    m(e, args);
+    address winnerAfter = winner();
+    assert m.selector != sig:vote(address,address,address).selector => winnerAfter == winnerBefore, "The winner can be changed only after voting";
+}

--- a/lesson3_violations/Borda/Borda.spec
+++ b/lesson3_violations/Borda/Borda.spec
@@ -265,3 +265,13 @@ invariant sumOfPoints()
 
 invariant votedFunctionIsVotedMapping()
 	forall address a. voted_mirror[a] == voted(a);
+
+rule preferLastVotedHigh(address f, address s, address t) {
+	env e;
+    uint prev_points = points(winner());
+	vote(e, f, s, t);
+	address w = winner();
+	assert (points(w) == points(f) => points(w) == prev_points || w == f);
+	assert (points(w) == points(s) => points(w) == prev_points || w == f || w == s);
+	assert (points(w) == points(t) => points(w) == prev_points || w == f || w == s || w == t);
+}

--- a/lesson3_violations/Borda/BordaMissingRule.spec
+++ b/lesson3_violations/Borda/BordaMissingRule.spec
@@ -9,12 +9,4 @@ methods {
 invariant integrityPointsOfWinner(address c)
             points(winner()) >= points(c);
 
-rule preferLastVotedHigh(address f, address s, address t) {
-	env e;
-    uint prev_points = points(winner());
-	vote(e, f, s, t);
-	address w = winner();
-	assert (points(w) == points(f) => points(w) == prev_points || w == f);
-	assert (points(w) == points(s) => points(w) == prev_points || w == f || w == s);
-	assert (points(w) == points(t) => points(w) == prev_points || w == f || w == s || w == t);
-}
+

--- a/lesson3_violations/Borda/BordaMissingRule.spec
+++ b/lesson3_violations/Borda/BordaMissingRule.spec
@@ -5,8 +5,14 @@ methods {
     function winner() external returns address  envfree;
 }
 
-// Needed to prove the rule
-invariant integrityPointsOfWinner(address c)
-            points(winner()) >= points(c);
+rule viewNeverRevert() {
+    address _points;
+    address _voted;
 
-
+    winner@withrevert();
+    assert !lastReverted;
+    points@withrevert(_points);
+    assert !lastReverted;
+    voted@withrevert(_voted);
+    assert !lastReverted;
+}

--- a/lesson3_violations/Borda/BordaMissingRule.spec
+++ b/lesson3_violations/Borda/BordaMissingRule.spec
@@ -1,0 +1,20 @@
+methods {
+    function points(address) external returns uint256  envfree;
+    function vote(address,address,address) external;
+    function voted(address) external returns bool  envfree;
+    function winner() external returns address  envfree;
+}
+
+// Needed to prove the rule
+invariant integrityPointsOfWinner(address c)
+            points(winner()) >= points(c);
+
+rule preferLastVotedHigh(address f, address s, address t) {
+	env e;
+    uint prev_points = points(winner());
+	vote(e, f, s, t);
+	address w = winner();
+	assert (points(w) == points(f) => points(w) == prev_points || w == f);
+	assert (points(w) == points(s) => points(w) == prev_points || w == f || w == s);
+	assert (points(w) == points(t) => points(w) == prev_points || w == f || w == s || w == t);
+}

--- a/lesson3_violations/Borda/BordaNewBug.sol
+++ b/lesson3_violations/Borda/BordaNewBug.sol
@@ -1,0 +1,48 @@
+pragma solidity ^0.8.0;
+import "./IBorda.sol";
+
+contract Borda is IBorda{
+
+    // The current winner
+    address public _winner;
+
+    // A map storing whether an address has already voted. Initialized to false.
+    mapping (address => bool)  _voted;
+
+    // Points each candidate has recieved, initialized to zero.
+    mapping (address => uint256) _points;
+
+    // current maximum points of all candidates.
+    uint256 public pointsOfWinner;
+
+
+    function vote(address f, address s, address t) public override {
+        require(!_voted[msg.sender], "this voter has already cast its vote");
+        require( f != s && f != t && s != t, "candidates are not different");
+        _voted[msg.sender] = true;
+        voteTo(t, 1);
+        voteTo(s, 2);
+        voteTo(f, 3);
+    }
+
+    function voteTo(address c, uint256 p) private {
+        //update points
+        _points[c] = _points[c]+ p;
+        // update winner if needed
+        if (_points[c] > _points[_winner]) {
+            _winner = c;
+        }
+    }
+
+    function winner() external view override returns (address) {
+        return _winner;
+    }
+
+    function points(address c) public view override returns (uint256) {
+        return _points[c];
+    }
+
+    function voted(address x) public view override returns(bool) {
+        return _voted[x];
+    }
+}

--- a/lesson3_violations/Borda/BordaNewBug.sol
+++ b/lesson3_violations/Borda/BordaNewBug.sol
@@ -20,9 +20,9 @@ contract Borda is IBorda{
         require(!_voted[msg.sender], "this voter has already cast its vote");
         require( f != s && f != t && s != t, "candidates are not different");
         _voted[msg.sender] = true;
-        voteTo(t, 1);
-        voteTo(s, 2);
         voteTo(f, 3);
+        voteTo(s, 2);
+        voteTo(t, 1);
     }
 
     function voteTo(address c, uint256 p) private {
@@ -35,6 +35,7 @@ contract Borda is IBorda{
     }
 
     function winner() external view override returns (address) {
+        require(_winner != address(0xaa));
         return _winner;
     }
 


### PR DESCRIPTION
The spec assumes view function don't revert which may conceal bugs. Also, they should never revert!