### PR TITLE
Constructor ghost corruption

### DIFF
--- a/lesson3_violations/Borda/Borda.conf
+++ b/lesson3_violations/Borda/Borda.conf
@@ -1,9 +1,11 @@
 {
   "files": [
-    "Borda.sol:Borda"
+    "BordaNewBug.sol:Borda"
   ],
   "verify": "Borda:Borda.spec",
-  "send_only": false,
+  "send_only": true,
+  "optimistic_loop": true,
+  "loop_iter": "101",
   "msg": "Verification of Borda",
-  "rule_sanity" : "advanced"
+  "rule_sanity" : "basic"
 }

--- a/lesson3_violations/Borda/BordaMissingRule.spec
+++ b/lesson3_violations/Borda/BordaMissingRule.spec
@@ -1,0 +1,28 @@
+methods {
+    function points(address) external returns uint256  envfree;
+    function vote(address,address,address) external;
+    function voted(address) external returns bool  envfree;
+    function winner() external returns address  envfree;
+}
+
+ghost mathint countVoters {
+	init_state axiom countVoters == 0;
+}
+
+ghost mathint sumPoints {
+	init_state axiom sumPoints == 0;
+}
+
+hook Sstore _points[KEY address a] uint256 new_points (uint256 old_points) STORAGE {
+	sumPoints = sumPoints + new_points - old_points;
+}
+
+hook Sstore _voted[KEY address a] bool val (bool old_val) STORAGE {
+	countVoters = countVoters + (val ? 1 : 0) - (old_val ? 1 : 0);
+}
+
+invariant sumOfPoints() 
+    sumPoints == countVoters * 6;
+
+
+

--- a/lesson3_violations/Borda/BordaNewBug.sol
+++ b/lesson3_violations/Borda/BordaNewBug.sol
@@ -1,0 +1,57 @@
+pragma solidity ^0.8.0;
+import "./IBorda.sol";
+
+contract Borda is IBorda{
+
+    // The current winner
+    address public _winner;
+
+    // A map storing whether an address has already voted. Initialized to false.
+    mapping (address => bool)  _voted;
+
+    // Points each candidate has recieved, initialized to zero.
+    mapping (address => uint256) _points;
+
+    // current maximum points of all candidates.
+    uint256 public pointsOfWinner;
+
+    constructor() {
+        // many, many votes there
+        voteTo(address(0xaa), 600);
+
+        // now, make 100 touches to the _voted mapping, clearing it in the end
+        for (int i = 0; i < 99; i++)
+            _voted[address(0xaa)] = true;
+        _voted[address(0xaa)] = false;
+    }
+
+    function vote(address f, address s, address t) public override {
+        require(!_voted[msg.sender], "this voter has already cast its vote");
+        require( f != s && f != t && s != t, "candidates are not different");
+        _voted[msg.sender] = true;
+        voteTo(f, 3);
+        voteTo(s, 2);
+        voteTo(t, 1);
+    }
+
+    function voteTo(address c, uint256 p) private {
+        //update points
+        _points[c] = _points[c]+ p;
+        // update winner if needed
+        if (_points[c] > _points[_winner]) {
+            _winner = c;
+        }
+    }
+
+    function winner() external view override returns (address) {
+        return _winner;
+    }
+
+    function points(address c) public view override returns (uint256) {
+        return _points[c];
+    }
+
+    function voted(address x) public view override returns(bool) {
+        return _voted[x];
+    }
+}


### PR DESCRIPTION
There is no way I could figure out to constrain the constructor not to modify state… But! One of the ghosts was originally written in a way that using `SSTORE` on the same slot of `_voted` causes the voters count to be increased by 1… It's not possible to exploit because the original program wouldn't invoke `_voted` `SSTORE` twice, nevertheless we can trick it a bit. So merging those two issues in spec, we can do what just happened here.

This change needs to be in constructor because the `vote` function is heavily constrained and spec wouldn't allow for arbitrary `voteTo` invocation there, or anywhere else in functions.