### PR TITLE
for Borda bug bounty,pointsOfWinner not sync with points of winner

### DIFF
--- a/lesson3_violations/Borda/BordaNewBug.sol
+++ b/lesson3_violations/Borda/BordaNewBug.sol
@@ -1,0 +1,47 @@
+pragma solidity ^0.8.0;
+import "./IBorda.sol";
+
+contract Borda is IBorda {
+    // The current winner
+    address public _winner;
+
+    // A map storing whether an address has already voted. Initialized to false.
+    mapping(address => bool) _voted;
+
+    // Points each candidate has recieved, initialized to zero.
+    mapping(address => uint256) _points;
+
+    // current maximum points of all candidates.
+    uint256 public pointsOfWinner;
+
+    function vote(address f, address s, address t) public override {
+        require(!_voted[msg.sender], "this voter has already cast its vote");
+        require(f != s && f != t && s != t, "candidates are not different");
+        _voted[msg.sender] = true;
+        voteTo(f, 3);
+        voteTo(s, 2);
+        voteTo(t, 1);
+    }
+
+    function voteTo(address c, uint256 p) private {
+        //update points
+        _points[c] = _points[c] + p;
+        // update winner if needed
+        if (_points[c] > _points[_winner]) {
+            _winner = c;
+            pointsOfWinner = _points[c];
+        }
+    }
+
+    function winner() external view override returns (address) {
+        return _winner;
+    }
+
+    function points(address c) public view override returns (uint256) {
+        return _points[c];
+    }
+
+    function voted(address x) public view override returns (bool) {
+        return _voted[x];
+    }
+}

--- a/lesson3_violations/Borda/bounty_specs/BordaMissingRule.spec
+++ b/lesson3_violations/Borda/bounty_specs/BordaMissingRule.spec
@@ -87,6 +87,7 @@ invariant integrityPointsOfWinner(address c)
 //pointsOfWinner should be winner's point
 rule BordaMissingRule(address f, address s, address t) {
     env e;
+    require(pointsOfWinner()==0);
     vote(e, f, s, t);
     assert (pointsOfWinner()==0)||(pointsOfWinner() == points(winner())),   "unexpected change of points";
 }

--- a/lesson3_violations/Borda/bounty_specs/BordaMissingRule.spec
+++ b/lesson3_violations/Borda/bounty_specs/BordaMissingRule.spec
@@ -1,0 +1,265 @@
+/*
+ * Borda Example
+ * -------------
+ *
+ * Verification of a simple voting contract which uses a Borda election.
+ * See https://en.wikipedia.org/wiki/Borda_count
+ */
+
+
+
+methods {
+    function points(address) external returns uint256  envfree;
+    function vote(address,address,address) external;
+    function voted(address) external returns bool  envfree;
+    function winner() external returns address  envfree;
+    function pointsOfWinner() external returns uint256  envfree;
+}
+
+/*
+After voting, a user is marked as voted
+    vote(e, f, s, t) => voted(e.msg.sender)
+*/
+rule integrityVote(address f, address s, address t) {
+    env e;
+    vote(e, f, s, t); //considering only non reverting cases 
+    assert voted(e.msg.sender), "A user voted without being marked accordingly";
+}
+
+/*
+Single vote per user
+    A user cannot vote if he has voted before
+    voted(e.msg.sender) => ㄱvote(e, f, s, t)
+*/
+rule singleVote(address f, address s, address t) {
+    env e;
+    bool has_voted_before = voted(e.msg.sender);
+    vote@withrevert(e, f, s, t); //considering all cases
+    assert has_voted_before => lastReverted, "Double voting is not allowed";
+}
+
+/*
+Integrity of points:
+    When voting, the points each candidate gets are updated as expected. 
+    This rule also verifies that there are three distinct candidates.
+
+    { points(f) = f_points ⋀ points(s) = s_points ⋀ points(t) = t_points }
+    vote(e, f, s, t)
+    { points(f) = f_points + 3 ⋀ points(s) = s_points + 2 ⋀ points(t) = t_points + 1 }
+*/
+rule integrityPoints(address f, address s, address t) {
+    env e;
+    uint256 f_points = points(f);
+    uint256 s_points = points(s);
+    uint256 t_points = points(t);
+    vote(e, f, s, t);
+    assert to_mathint(points(f)) == f_points + 3 &&
+           to_mathint(points(s)) == s_points + 2 &&
+           to_mathint(points(t)) == t_points + 1,   "unexpected change of points";
+}
+
+/*
+Integrity of voted:
+    Once a user casts their vote, they are marked as voted globally (for all future states).
+    vote(e, f, s, t)  Globally voted(e.msg.sender)
+*/
+rule globallyVoted(address x, method f) {
+    require voted(x);
+    env eF;
+    calldataarg arg;
+    f(eF,arg); //taking into account all external function with all possible arguments 
+    assert voted(x), "Once a user voted, he is marked as voted in all future states";
+}
+
+/*
+ Integrity of winner
+    The winner has the most points.
+    winner() = forall ∀address c. points(c) ≤ points(w)
+
+
+    Note: The Prover checks that the invariant is established after the constructor. In addition, Prover checks that the invariant holds after the execution of any contract method, assuming that it held before the method was executed.
+    Note that c is an unconstrained variable therefore this invariant is checked against all possible values of c. 
+*/
+invariant integrityPointsOfWinner(address c)
+            points(winner()) >= points(c);
+
+//pointsOfWinner should be 0 in original Borda.sol 
+//pointsOfWinner should be winner's point
+rule BordaMissingRule(address f, address s, address t) {
+    env e;
+    vote(e, f, s, t);
+    assert (pointsOfWinner()==0)||(pointsOfWinner() == points(winner())),   "unexpected change of points";
+}
+
+/*
+Vote is the only state-changing function. 
+A vote can only affect the voter and the selected candidates, and has no effect on other addresses.
+    ∀address c, c ≠ {f, s, t}.
+    { c_points = points(c) ⋀ b = voted(c) }  vote(e, f, s, t)  { points(c) = c_points ⋀ ( voted(c) = b V c = e.msg.sender ) }
+*/
+rule noEffect(method m) {
+    address c;
+    env e;
+    uint256 c_points = points(c);
+    bool c_voted = voted(c);
+    if (m.selector == sig:vote(address, address, address).selector) {
+        address f;
+        address s;
+        address t;
+        require( c != f  &&  c != s  &&  c != t );
+        vote(e, f, s, t);
+    }
+    else {
+        calldataarg args;
+        m(e, args);
+    }
+    assert ( voted(c) == c_voted || c  == e.msg.sender ) &&
+             points(c) == c_points, "unexpected change to others points or voted";
+}
+
+
+/*
+Commutativity of votes.
+    The order of votes is not important
+    vote(e, f, s, t) ; vote(e’, f’, s’, t’)  ～  vote(e’, f’, s’, t’) ; vote(e, f, s, t)
+
+    Note: This is a hyperproperty  as it compares the results of different executions. 
+*/
+rule voteCommutativity(address f1, address s1, address t1, address f2, address s2, address t2) {
+    env e1;
+    env e2;
+    address c;
+    address y;
+    // A variable of type storage represents a snapshot of the EVM storage
+    storage init = lastStorage;  
+    
+
+    // First 1 votes, then 2
+    vote(e1, f1, s1, t1);
+    vote(e2, f2, s2, t2);
+    uint256 case1 = points(c);  
+
+    // EVM storage is reset to the saved storage value
+    vote(e2, f2, s2, t2) at init;
+    vote(e1, f1, s1, t1);
+    uint256 case2 = points(c);  
+    // Assert commutativity with respect to points (but not winner...)
+    assert case1 == case2, 
+        "vote() is not commutative";
+}
+
+
+/*
+Ability to vote
+    If a user can vote, no other user can prevent him to do so by any operation.
+    vote(e, f, s, t) ~ op; vote(e, f, s, t) (unless reached max_uint)
+*/
+rule allowVote(address f, address s, address t, method m) {
+    env e;
+    storage init = lastStorage;
+    vote(e, f, s, t);  // Ensures the user can vote
+
+    env eOther;
+    require (e.msg.sender != eOther.msg.sender);
+    calldataarg args;
+    m(eOther, args) at init; //reset to the initial state
+
+    require points(f) < max_uint256 - 3  &&  points(s)  < max_uint256 - 2  &&  points(t) < max_uint256 ; // No overflow
+
+    vote@withrevert(e, f, s, t);
+
+    assert !lastReverted, "a user can not be blocked from voting";
+}
+
+
+/*
+Revert case of vote
+    A user can vote, unless overflow in points or she has voted already 
+*/
+rule oneCanVote(address f, address s, address t) {
+    env e;
+    require e.msg.value == 0 ; //ignore revert on non payable
+    bool overflowCheck = ( points(f) <= max_uint256 - 3  &&  points(s) <= max_uint256 - 2  &&  points(t) < max_uint256 );
+    bool _voted = voted(e.msg.sender);
+    vote@withrevert(e, f, s, t);
+    bool reverted = lastReverted;
+
+    //TODO: it is not clear to me what the part "or same candidates" should mean exactly in the error message. Do you mean "...and all values for f,s,t differ." or negated "... or at least two values of f,s,t are the same."?
+    assert (  overflowCheck && !_voted && f!=s && s!=t && f!=t ) 
+            <=>  !reverted, "a user who hasn't yet voted should be able to do so unless there is an overflow or same candidates ";
+}
+
+
+/*
+Participation criterion
+    Abstaining from an election can not help a voter's preferred choice
+    https://en.wikipedia.org/wiki/Participation_criterion
+
+    { w1 = winner() }
+        ( vote(e, f, s, t) )
+    { winner() = f => (w1 = f) }
+*/
+rule participationCriterion(address f, address s, address t) {
+    env e;
+    address w1 = winner();
+    require points(w1) >= points(f);
+    require points(w1) >= points(s);
+    require points(w1) >= points(t);
+    vote(e, f, s, t);
+    address w2 = winner();
+    assert w1 == f => w2 == f, "winner changed unexpectedly";
+}
+
+/*
+Resolvability criterion 
+    Given a tie, there is a way for one added vote to make that winner unique.
+    This property is proven by showing that given a tie , there is a vote that makes the winner unique.
+
+    Note: This is implemented with the satisfy statement as the property require that exist a scenario and  not on every vote the tie must break.
+    This property require uses quantifiers which works over ghost 
+*/
+
+// Ghosts are additional variables for use during verification,  and often used to communicate information between rules and hooks.
+ 
+
+ghost mapping(address => uint256) points_mirror {
+ init_state axiom forall address c. points_mirror[c] == 0;
+} 
+
+ghost mathint countVoters {
+    init_state axiom countVoters == 0;
+}
+ghost mathint sumPoints {
+    init_state axiom sumPoints == 0;
+}
+
+/* update ghost on changes to _points */
+hook Sstore _points[KEY address a] uint256 new_points (uint256 old_points) STORAGE {
+  points_mirror[a] = new_points;
+  sumPoints = sumPoints + new_points - old_points;
+}
+
+hook Sload uint256 curr_point _points[KEY address a]  STORAGE {
+  require points_mirror[a] == curr_point;
+}
+
+hook Sstore _voted[KEY address a] bool val (bool old_val) STORAGE {
+  countVoters = countVoters +1;
+}
+
+
+rule resolvabilityCriterion(address f, address s, address t, address tie) {
+    env e;
+    address winnerBefore = winner(); 
+    require (points(tie) == points(winner()));
+    require forall address c. points_mirror[c] <= points_mirror[winnerBefore];
+    vote(e, f, s, t);
+    address winnerAfter = winner(); 
+    satisfy forall address c. c != winnerAfter => points_mirror[c] < points_mirror[winnerAfter];
+}
+
+/*
+  Each voter contribute a total of 6 points, so the sum of all points is six time the number of voters 
+*/
+invariant sumOfPoints() 
+    sumPoints == countVoters * 6; 


### PR DESCRIPTION
A run of the new BordaMissingRule.spec on the original Borda.sol that is verified
https://prover.certora.com/output/738862/2cc3abb2da82413ca269ee65d7b29d0a?anonymousKey=c0979cf572194bb4629657192c849ba54d61c6fc
I am not sure about this one,maybe it's Certora's bug?Because there's no place to set pointsOfWinner

A run of Borda.spec on BordaNewBug.sol showing the existing spec misses the bug
https://prover.certora.com/output/738862/82ed220f31a2486c9db0822b8f142a9b?anonymousKey=f7312a8b2f71bb5d4b3ea84c54d1ca13887082eb

A run of BordaMissingRule.spec on BordaNewBug.sol showing your rule catches the bug
https://prover.certora.com/output/738862/398479f4d55846dfb15357b979df22ca?anonymousKey=8af8a5216248987b9d413ffcff06463941faee87