### PR TITLE
Vacuity examples

### DIFF
--- a/lesson2_started/vacuity/Vacuous.conf
+++ b/lesson2_started/vacuity/Vacuous.conf
@@ -1,0 +1,8 @@
+{
+    "files": [
+        "Vacuous.sol"
+    ],
+    "verify": "Vacuous:Vacuous.spec",
+    "wait_for_results": "all",
+    "msg": "Vacuous rules without sanity check"
+}

--- a/lesson2_started/vacuity/Vacuous.sol
+++ b/lesson2_started/vacuity/Vacuous.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+
+/// @title Examples of vacuous rules
+contract Vacuous {
+
+  mapping (address => uint256) public amounts;
+  uint256 public immutable maximalAmount = 1000;
+
+  function add(address user, uint256 amount) public returns (uint256) {
+    require(amounts[user] + amount <= maximalAmount);
+    amounts[user] += amount;
+    return amounts[user];
+  }
+
+  function sub(address user, uint256 amount) public returns (uint256) {
+    amounts[user] -= amount;
+    return amounts[user];
+  }
+}

--- a/lesson2_started/vacuity/Vacuous.sol
+++ b/lesson2_started/vacuity/Vacuous.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-
 /// @title Examples of vacuous rules
 contract Vacuous {
 

--- a/lesson2_started/vacuity/Vacuous.spec
+++ b/lesson2_started/vacuity/Vacuous.spec
@@ -1,0 +1,32 @@
+/**
+ * Vacuous rules examples
+ */
+methods {
+    function amounts(address) external returns (uint256) envfree;
+    function maximalAmount() external returns (uint256) envfree;
+    function add(address, uint256) external returns (uint256) envfree;
+    function sub(address, uint256) external returns (uint256) envfree;
+}
+
+
+rule simpleVacuousRule(uint256 x, uint256 y) {
+    // Contradictory requirement
+    require (x > y) && (y > x);
+    assert false;  // Should always fail
+}
+
+
+rule subtleVacuousRule(address user, uint256 amount) {
+    uint256 userAmount = amounts(user);
+    require amount > userAmount;
+    sub(user, amount);
+    assert false;  // Should always fail
+}
+
+
+rule revertingRule(address user, uint256 amount) {
+    uint256 userAmount = amounts(user);
+    require amount > userAmount;
+    sub@withrevert(user, amount);
+    assert lastReverted;
+}

--- a/lesson2_started/vacuity/Vacuous_sanity.conf
+++ b/lesson2_started/vacuity/Vacuous_sanity.conf
@@ -1,0 +1,9 @@
+{
+    "files": [
+        "Vacuous.sol"
+    ],
+    "verify": "Vacuous:Vacuous.spec",
+    "wait_for_results": "all",
+    "rule_sanity": "basic",
+    "msg": "Vacuous rules with sanity check"
+}


### PR DESCRIPTION
Small examples of vacuous rules and using `@withrevert`.