### PR TITLE
added .gitattributes for Git syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.spec linguist-language=Solidity
+*.conf linguist-detectable
+*.conf linguist-language=JSON5


### PR DESCRIPTION
Adding GitHub syntax highlighting for `.conf` and `.spec` files as explained in https://docs.certora.com/en/latest/docs/user-guide/github_highlighting.html